### PR TITLE
Add webpack_done event.

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -213,6 +213,7 @@ function Plugin(
       blocked[i]();
     }
     blocked = [];
+    emitter.emit('webpack_done', applyStats);
   }
 
   function invalid() {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This allows to perform certain actions once a compilation is done, when using the karma api.
Example use case:
Run tests every time a compilation has finished.
```js
const { Server, runner } = require('karma');
const karma = new Server(config);
karma.start();
karma.on(
  'webpack_done', 
  () => runner.run(config, () => {})
);
```

### Breaking Changes

None.

### Additional Info

There is currently a workaround to still allow running test on every webpack compile, with webpack-karma:
```js
const { Server, runner } = require('karma');

const karma = new Server(config);
karma.start();

let ready = false;
karma.once('browsers_ready', () => (ready = true));
executeWhenReady = func =>
  ready ? func() : emitter.once('browsers_ready', func);

executeWhenReady(startKarmaAutoRun.bind(null, config, karma));

function startKarmaAutoRun(config, emitter) {
  // We need to use once and reregister the event,
  // because the run itself triggers the file_list_modified
  // event.
  // Note that the file_list_modified event is not part of karmas public api, 
  // but it's the only way to detect the webpack rebuild until
  // https://github.com/webpack-contrib/karma-webpack/pull/430 is merged.
  KarmaRunner.run(config, () =>
    emitter.once(
      'file_list_modified',
      startKarmaAutoRun.bind(null, config, emitter)
    )
  );
}
```