### PR TITLE
fix: cross disk relative paths

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -31,6 +31,17 @@ const getOutputPath = (outputPath) => {
   return null;
 };
 
+const getRelativePath = (basePath, file) => {
+  // Check if paths have different roots.
+  const parsedBasePath = path.parse(basePath);
+  const parsedFilePath = path.parse(file);
+  if (parsedBasePath.root !== parsedFilePath.root) {
+    file = basePath[0] + file.substring(1);
+  }
+
+  return path.relative(basePath, file);
+};
+
 const escapeRegExp = (str) => {
   // See details here https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
   return str.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
@@ -289,7 +300,7 @@ Plugin.prototype.make = function(compilation, callback) {
       const dep = new SingleEntryDependency(entry);
 
       const filename = normalize(
-        path.relative(this.basePath, file).replace(/\\/g, '/')
+        getRelativePath(this.basePath, file).replace(/\\/g, '/')
       );
       const name = path.join(
         path.dirname(filename),
@@ -398,7 +409,7 @@ function createPreprocesor(/* config.basePath */ basePath, webpackPlugin) {
       invalidate(webpackPlugin.middleware);
     }
 
-    const filename = path.relative(basePath, file.originalPath);
+    const filename = getRelativePath(basePath, file.originalPath);
     // read blocks until bundle is done
     webpackPlugin.readFile(filename, (err, content) => {
       if (err) {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
We use Karma and Webpack, as the base for a testing tool, which can be installed globally. On Windows there is an issue when the tool is installed on one drive (C:\), and the codebase being tested is on another drive (F:\).

The issue is with relative path resolving on two absolute paths on different roots/drives, which returns an absolute path. This causes the process to get stuck infinitely after compilation, due to not being able to read the output (because the lookup key is not relative).

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes
There are no breaking changes.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
