### PR TITLE
fix: honor webpack's `bail` by emulation inside plugin

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -172,9 +172,15 @@ function Plugin(
 
     applyStats.forEach((stats, index) => {
       if (this.emulateBail[index] && stats.hasErrors()) {
-        this.emitter.dieOnError(
-          'Errors during during webpack compilation, bailing'
-        );
+        const karmaConfig = this.emitter.get('config');
+        if (karmaConfig.singleRun) {
+          this.emitter.dieOnError(
+            'Errors during during webpack compilation, bailing'
+          );
+        } else {
+          noAssets = true;
+          return;
+        }
       }
 
       stats = stats.toJson();

--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -125,6 +125,9 @@ function Plugin(
   this.entries = new Map();
   this.outputs = new Map();
   this.plugin = { name: 'KarmaWebpack' };
+  this.emulateBail = applyOptions.map(
+    (webpackOptions) => webpackOptions.bail || false
+  );
 
   let compiler;
 
@@ -167,7 +170,13 @@ function Plugin(
     const assets = [];
     let noAssets = false;
 
-    applyStats.forEach((stats) => {
+    applyStats.forEach((stats, index) => {
+      if (this.emulateBail[index] && stats.hasErrors()) {
+        this.emitter.dieOnError(
+          'Errors during during webpack compilation, bailing'
+        );
+      }
+
       stats = stats.toJson();
 
       this.outputs.clear();


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
As long as #66 (which is about `bail` not being honored by webpack) is
not fixed, we can emulate equivalent behavior inside the plugin as an
alternative solution. If the webpack compilation step finishes with
errors and the `bail` option is set to true, we exit Karma with a
nonzero exit status. This way, we can still prevent Karma from silently
continuing upon webpack compilation errors.
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
