### PR TITLE
fix(docs): fix README webpack syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ And tell `webpack` to generate sourcemaps.
 ```js
 webpack: {
   // ...
-  devtool: 'inline-source-map';
+  'devtool': 'inline-source-map'
 }
 ```
 


### PR DESCRIPTION
  
 make the webpack devtool configuration in README
  syntactically correct and consistent with the
  other configurations in the file.
  
  Fixes N/A

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Hopefully this will save someone a fraction of the second whilst shamelessly copy and pasting the devtool configuration into their own project 😉

### Breaking Changes

Nope

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

Nope
