### PR TITLE
fix(karma-webpack): close `middleware` on compile `done` in `singleRu…

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -213,6 +213,10 @@ function Plugin(
       blocked[i]();
     }
     blocked = [];
+
+    if (singleRun) {
+      this.middleware.close();
+    }
   }
 
   function invalid() {
@@ -252,7 +256,9 @@ function Plugin(
   });
 
   emitter.on('exit', (done) => {
-    middleware.close();
+    if (!singleRun) {
+      middleware.close();
+    }
     done();
   });
 }


### PR DESCRIPTION
…n` mode

When in `singleRun` mode, close the webpack dev middleware once the
compilation is done. Otherwise, webpack listens to file changes and
re-compiles them while the test is running.

Closes #448

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

It fixes #448

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
