### PR TITLE
Fix getPathKey for TypeScript files

### DIFF
--- a/lib/karma-webpack.js
+++ b/lib/karma-webpack.js
@@ -50,9 +50,8 @@ function hash(s) {
 }
 
 function getPathKey(filePath, withExtension = false) {
-  const fixedFilePath = filePath.replace('.ts', '.js');
-  const pathParts = path.parse(fixedFilePath);
-  const key = `${pathParts.name}.${hash(fixedFilePath)}`;
+  const pathParts = path.parse(filePath);
+  const key = `${pathParts.name}.${hash(filePath)}`;
   return withExtension ? `${key}${pathParts.ext}` : key;
 }
 
@@ -84,7 +83,7 @@ function configToWebpackEntries(config) {
 
   const webpackEntries = {};
   filteredFiles.forEach((filePath) => {
-    webpackEntries[getPathKey(filePath)] = filePath;
+    webpackEntries[getPathKey(filePath.replace(/\.tsx?$/, '.js'))] = filePath;
   });
 
   return webpackEntries;

--- a/lib/karma-webpack.js
+++ b/lib/karma-webpack.js
@@ -50,8 +50,9 @@ function hash(s) {
 }
 
 function getPathKey(filePath, withExtension = false) {
-  const pathParts = path.parse(filePath);
-  const key = `${pathParts.name}.${hash(filePath)}`;
+  const fixedFilePath = filePath.replace('.ts', '.js');
+  const pathParts = path.parse(fixedFilePath);
+  const key = `${pathParts.name}.${hash(fixedFilePath)}`;
   return withExtension ? `${key}${pathParts.ext}` : key;
 }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lib"
   ],
   "peerDependencies": {
-    "webpack": "^4.0.0"
+    "webpack": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "glob": "^7.1.3",


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I was seeing the same problem reported by @thijstriemstra:

https://github.com/ryanclark/karma-webpack/issues/450#issuecomment-707961142

I am using TypeScript and the cause seems to be that getPathKey uses '.ts. to generate the hash for the file contents when creating the bundle but tries to use '.js' when reading it back.  As the key is different, the bundle is not found, causing the error.  This patch fixes this for .ts files.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
