### PR TITLE
fix path argument must be of type string error

### DIFF
--- a/src/karma-webpack.js
+++ b/src/karma-webpack.js
@@ -354,16 +354,18 @@ Plugin.prototype.readFile = function(file, callback) {
         }
       );
     } else {
+      let output = this.outputs.get(file);
+
       try {
         const fileContents = middleware.fileSystem.readFileSync(
-          path.join(os.tmpdir(), '_karma_webpack_', this.outputs.get(file))
+          path.join(os.tmpdir(), '_karma_webpack_', output)
         );
 
         callback(null, fileContents);
       } catch (e) {
         // If this is an error from `readFileSync` method, wait for the next tick.
         // Credit #69 @mewdriller
-        if (e.code === 'ENOENT') {
+        if (e.code === 'ENOENT' || !output) {
           // eslint-disable-line quotes
           this.waiting = [
             process.nextTick.bind(


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [X] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Intermittently the call to `this.outputs.get(file);` is undefined.  Checking for the presence of this file and waiting if its not there fixes the problem.

```
10 12 2020 18:37:17.496:ERROR [karma-server]: UnhandledRejection
infrastructure_error TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined
    at validateString (internal/validators.js:125:11)
    at Object.join (path.js:1147:7)
    at Plugin.<anonymous> (/Users/me/my-app/node_modules/karma-webpack/dist/karma-webpack.js:318:70)
    at Plugin.readFile (/Users/me/my-app/node_modules/karma-webpack/dist/karma-webpack.js:334:5)
    at /Users/me/my-app/node_modules/karma-webpack/dist/karma-webpack.js:353:19
    at executeProcessor (/Users/me/my-app/node_modules/karma/lib/preprocessor.js:28:11)
    at runProcessors (/Users/me/my-app/node_modules/karma/lib/preprocessor.js:41:23)
    at /Users/me/my-app/node_modules/karma/lib/preprocessor.js:144:9
    at module.exports (/Users/me/my-app/node_modules/isbinaryfile/index.js:29:12)
    at readFileCallback (/Users/me/my-app/node_modules/karma/lib/preprocessor.js:116:7)
    at /Users/me/my-app/node_modules/graceful-fs/graceful-fs.js:90:16
    at FSReqWrap.readFileAfterClose [as oncomplete] (internal/fs/read_file_context.js:53:3)
From previous event:
    at Promise.map (/Users/me/my-app/node_modules/karma/lib/file-list.js:89:51)
From previous event:
    at Promise.map (/Users/me/my-app/node_modules/karma/lib/file-list.js:89:25)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
From previous event:
    at FileList._refresh (/Users/me/my-app/node_modules/karma/lib/file-list.js:64:8)
    at FileList.refresh (/Users/me/my-app/node_modules/karma/lib/file-list.js:158:29)
    at Server.refreshFiles (/Users/me/my-app/node_modules/karma/lib/server.js:146:44)
    at Plugin.notifyKarmaAboutChanges (/Users/me/my-app/node_modules/karma-webpack/dist/karma-webpack.js:250:16)
    at Plugin.done (/Users/me/my-app/node_modules/karma-webpack/dist/karma-webpack.js:193:12)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/me/my-app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:27:1)
    at AsyncSeriesHook.lazyCompileHook (/Users/me/my-app/node_modules/tapable/lib/Hook.js:154:20)
    at Watching._done (/Users/me/my-app/node_modules/webpack/lib/Watching.js:98:28)
    at compiler.emitRecords.err (/Users/me/my-app/node_modules/webpack/lib/Watching.js:73:19)
    at Compiler.emitRecords (/Users/me/my-app/node_modules/webpack/lib/Compiler.js:499:39)
    at compiler.emitAssets.err (/Users/me/my-app/node_modules/webpack/lib/Watching.js:54:20)
    at hooks.afterEmit.callAsync.err (/Users/me/my-app/node_modules/webpack/lib/Compiler.js:485:14)
    at _promise0.then._result0 (eval at create (/Users/me/my-app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:13:1)
```

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
