### PR TITLE
Fix empty chunks with webpack v5

### DIFF
--- a/lib/KarmaWebpackController.js
+++ b/lib/KarmaWebpackController.js
@@ -47,20 +47,6 @@ const defaultWebpackOptions = {
     colors: true,
   },
   watch: false,
-  optimization: {
-    runtimeChunk: 'single',
-    splitChunks: {
-      chunks: 'all',
-      minSize: 0,
-      cacheGroups: {
-        commons: {
-          name: 'commons',
-          chunks: 'all',
-          minChunks: 1,
-        },
-      },
-    },
-  },
   plugins: [],
   // Something like this will be auto added by this.configure()
   // entry: {


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Just tried to upgrade our karma setup over at https://github.com/preactjs/preact to webpack v5 and ran into the issue that all chunks contained no user code. They only contained a thin module wrapper by webpack.

```js
(self["webpackChunkpreact"] = self["webpackChunkpreact"] || []).push([["Children.test.159184821"],{},
0,[["./compat/test/browser/Children.test.js","runtime","commons"]]]);
```

Some digging revealed that the `optimize.splitChunks` settings are to blame. The [webpack v4 to v5 upgrade guide](https://webpack.js.org/migrate/5/#clean-up-configuration) hints that setting it is not necessary anymore. When I follow that advice and remove them, the chunks work as expected.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
