### PR TITLE
Webpack 5 and Webpacker 6 - Add note that output entry should also not be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ module.exports = (config) => {
 
     webpack: {
       // karma watches the test entry points
-      // Do NOT specify the entry option
+      // Do NOT specify the entry or output options
       // webpack watches dependencies
 
       // webpack configuration


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

I'm upgrading our app to webpacker 6 (webpack 5) and started hitting the snags discussed in https://github.com/ryanclark/karma-webpack/issues/450 and #452 

The fix was to add the following to the top of our karma.conf.js:

```js
const webpackConfig = require('./config/webpack/test.js')

// karma watches the test entry points, Do NOT specify the entry option
// From https://github.com/ryanclark/karma-webpack#getting-started
delete webpackConfig.entry
delete webpackConfig.output
```

As well as:

- Adding webpack to `frameworks: ['jasmine', 'webpack'],` (already covered in docs)
- Adding `watched: false` to files `{ pattern: 'spec/javascripts/**/*[sS]pec.js', watched: false },`

This PR just **adds that note about output** to the docs.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

None

### Additional Info


**Perhaps an example karma config file** for webpacker would also be of value to add to the readme?

For reference a filleted version of ours now looks like:

```js
const webpackConfig = require('./config/webpack/test.js')

// Remove entry and output from webpacker config
// Karma watches the test entry points, do not specify entry or output option
// From https://github.com/ryanclark/karma-webpack#getting-started
delete webpackConfig.entry
delete webpackConfig.output

module.exports = (config) => {
  config.set({
    // ... normal karma configuration

    // add webpack to your list of frameworks
    frameworks: ['mocha', 'webpack'],

    plugins: ['karma-webpack', 'karma-mocha'],

    files: [
      // all files ending in ".test.js"
      // !!! use watched: false as we use webpacks watch
      { pattern: 'test/**/*.test.js', watched: false },
    ],

    preprocessors: {
      // add webpack as preprocessor
      'test/**/*.test.js': ['webpack'],
    },

    webpack: webpackConfig,

    webpackMiddleware: {
      // webpack-dev-middleware configuration
      stats: 'errors-only',
    },
  })
}

```