### PR TITLE
Year of the linux desktop

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "husky": "^0.14.3",
     "istanbul": "^0.4.5",
     "jest": "^23.5.0",
-    "karma": "^6.0.0",
+    "karma": "^6.0.3",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-mocha": "^1.3.0",

--- a/test/integration/scenarios/basic-setup/basic-setup.test.js
+++ b/test/integration/scenarios/basic-setup/basic-setup.test.js
@@ -1,9 +1,12 @@
 /* eslint-disable prettier/prettier */
+
 import karmaChromeLauncher from 'karma-chrome-launcher';
 import karmaMocha from 'karma-mocha';
 import karmaChai from 'karma-chai';
 
 import ScenarioUtils from '../../utils/ScenarioUtils';
+
+process.env.CHROME_BIN = require('puppeteer').executablePath();
 
 const path = require('path');
 


### PR DESCRIPTION

    chore(test): fix testing on linux
    
    Some systems require the CHROME_BIN env
    variable to be set for karma to hook
    into the chrome binary for testing.
    I noticed this while setting up
    karma-webpack on my linux desktop.
    
    Fixes N/A


This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

This allows karma-webpack tests to run in certain linux environments where CHROME_BIN is not set automatically

### Breaking Changes

N/A

### Additional Info

N/A