### PR TITLE
fix(controller): add entropy to default dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ const defaultWebpackOptions = {
   mode: 'development',
   output: {
     filename: '[name].js',
-    path: path.join(os.tmpdir(), '_karma_webpack_'),
+    path: path.join(os.tmpdir(), '_karma_webpack_') + Math.floor(Math.random() * 1000000),
   },
   stats: {
     modules: false,

--- a/lib/KarmaWebpackController.js
+++ b/lib/KarmaWebpackController.js
@@ -36,7 +36,8 @@ const defaultWebpackOptions = {
   mode: 'development',
   output: {
     filename: '[name].js',
-    path: path.join(os.tmpdir(), '_karma_webpack_'),
+    // eslint-disable-next-line prettier/prettier
+    path: path.join(os.tmpdir(), '_karma_webpack_') + Math.floor(Math.random() * 1000000),
   },
   stats: {
     modules: false,

--- a/test/integration/scenarios/basic-setup/basic-setup.test.js
+++ b/test/integration/scenarios/basic-setup/basic-setup.test.js
@@ -39,13 +39,13 @@ describe('A basic karma-webpack setup', () => {
     ScenarioUtils.run(config)
       .then((res) => {
         scenario = res;
-        done();
       })
-      .catch((err) => {
-        jest.fail('Karma run has failed with an error', err);
-        done();
-      });
+      .finally(() => done());
   }, KARMA_SERVER_TIMEOUT);
+
+  it('should have an exit code of 1 because it contains a failing test', () => {
+    expect(scenario.exitCode).toBe(1);
+  })
 
   it('should have three successful test runs', () => {
     expect(scenario.success).toBe(3);


### PR DESCRIPTION
    fix(controller): add entropy to default dir
    
    This adds a random number to the end of the
    default karma_webpack directory. This will
    prevent projects running multiple instances
    of karma webpack in parallel from stepping
    on one another.
    
    Fixes #465

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Currently users trying to run multiple instances of karma-webpack will run into issues because the default
project directory is a static temporary directory. To fix this we add some random numbers to the end of the
directory so different builds running in parallel won't step on one another.

### Breaking Changes

N/A

### Additional Info

N/A