### PR TITLE
fix(preprocess): auto fix missing webpack framework

### DIFF
--- a/lib/karma-webpack.js
+++ b/lib/karma-webpack.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const glob = require('glob');
 const minimatch = require('minimatch');
 
+const { ensureWebpackFrameworkSet } = require('./karma/karmaConfigValidator');
+
 const { hash } = require('./utils/hash');
 
 const { KarmaWebpackController } = require('./KarmaWebpackController');
@@ -80,6 +82,8 @@ function configToWebpackEntries(config) {
 }
 
 function preprocessorFactory(config, emitter) {
+  ensureWebpackFrameworkSet(config);
+
   // one time setup
   if (controller.isActive === false) {
     controller.updateWebpackOptions({

--- a/lib/karma/karmaConfigValidator.js
+++ b/lib/karma/karmaConfigValidator.js
@@ -1,0 +1,13 @@
+function ensureWebpackFrameworkSet(karmaConfig) {
+  if (!Array.isArray(karmaConfig.frameworks)) {
+    karmaConfig.frameworks = [];
+  }
+  if (karmaConfig.frameworks.indexOf('webpack') === -1) {
+    console.warn(
+      'webpack was not included as a framework in karma configuration, setting this automatically...'
+    );
+    karmaConfig.frameworks.push('webpack');
+  }
+}
+
+module.exports = { ensureWebpackFrameworkSet };

--- a/test/integration/scenarios/basic-setup/basic-setup.test.js
+++ b/test/integration/scenarios/basic-setup/basic-setup.test.js
@@ -22,7 +22,7 @@ describe('A basic karma-webpack setup', () => {
   const TEST_PATH = path.resolve(__dirname, './index.scenario.js');
 
   const config = {
-    frameworks: ['webpack', 'mocha', 'chai'],
+    frameworks: ['mocha', 'chai'],
     files: [{ pattern: TEST_PATH }],
     preprocessors: { [TEST_PATH]: ['webpack'] },
     webpack: {},

--- a/test/unit/util/karmaConfigValidation.test.js
+++ b/test/unit/util/karmaConfigValidation.test.js
@@ -1,0 +1,29 @@
+const {
+  ensureWebpackFrameworkSet,
+} = require('../../../lib/karma/karmaConfigValidator');
+
+describe('karmaConfigValidation', () => {
+  describe('ensureWebpackFrameworkExists', () => {
+    let config;
+    beforeEach(() => (config = { frameworks: [] }));
+
+    it('should add webpack to the list of karma config frameworks if it did not already exist', () => {
+      ensureWebpackFrameworkSet(config);
+      expect(config.frameworks.length).toBe(1);
+      expect(config.frameworks[0]).toBe('webpack');
+    });
+
+    it('should add webpack to an existing list of frameworks', () => {
+      config.frameworks = ['foo', 'bar'];
+      ensureWebpackFrameworkSet(config);
+      expect(config.frameworks.length).toBe(3);
+      expect(config.frameworks).toContain('webpack');
+    });
+    it('should create a frameworks array if one does not exist', () => {
+      delete config.frameworks;
+      ensureWebpackFrameworkSet(config);
+      expect(config.frameworks.length).toBe(1);
+      expect(config.frameworks[0]).toBe('webpack');
+    });
+  });
+});


### PR DESCRIPTION
    fix(preprocess): auto fix missing webpack framework
    
    this is an issue that comes up often. As this is
    something that karma-webpack needs to function,
    we will automatically fix the configuration on
    the fly and emit a warning that the change was
    made.
    
    Fixes N/A

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

adding 'webpack' in the karma configuration is a new requirement in v5 that is often overlooked.
as this is required and the plugin will not work without this, we will fix the configuration on the fly
and emit a warning stating that the change was made.

### Breaking Changes

N/A

### Additional Info

N/A