### PR TITLE
fix(config): ignore entry options

### DIFF
--- a/lib/karma-webpack/controller.js
+++ b/lib/karma-webpack/controller.js
@@ -25,7 +25,7 @@ class KW_Controller {
       console.warn(
         `
 karma-webpack does not currently support customized filenames via
-webpack output.filename, if this is something you need consider opening a ticket.
+webpack output.filename, if this is something you need consider opening an issue.
 defaulting ${newOptions.output.filename} to [name].js.`.trim()
       );
       delete newOptions.output.filename;

--- a/lib/karma-webpack/preprocessor.js
+++ b/lib/karma-webpack/preprocessor.js
@@ -59,6 +59,16 @@ function KW_Preprocessor(config, emitter) {
       entry: configToWebpackEntries(config),
       watch: config.autoWatch,
     });
+
+    if (config.webpack.entry) {
+      console.warn(`
+karma-webpack does not currently support custom entries, if this is something you need,
+consider opening an issue.
+ignoring attempt to set the entry option...
+      `);
+      delete config.webpack.entry;
+    }
+
     controller.updateWebpackOptions(config.webpack);
     controller.karmaEmitter = emitter;
   }

--- a/test/integration/scenarios/basic-setup/custom-entry-path.test.js
+++ b/test/integration/scenarios/basic-setup/custom-entry-path.test.js
@@ -1,0 +1,68 @@
+/* eslint-disable prettier/prettier */
+
+import karmaChromeLauncher from 'karma-chrome-launcher';
+import karmaMocha from 'karma-mocha';
+import karmaChai from 'karma-chai';
+
+import Scenario from '../../utils/scenario';
+
+process.env.CHROME_BIN = require('puppeteer').executablePath();
+
+const path = require('path');
+
+const karmaWebpack = require('../../../../lib/index');
+
+// The karma server integration tests take longer than the jest 5 sec default,
+// we will give them 30 seconds to complete.
+const KARMA_SERVER_TIMEOUT = 30 * 1000;
+
+describe('A basic karma-webpack setup', () => {
+  let scenario;
+
+  const TEST_PATH = path.resolve(__dirname, './index.scenario.js');
+
+  const config = {
+    frameworks: ['mocha', 'chai', 'webpack'],
+    files: [{ pattern: TEST_PATH }],
+    preprocessors: { [TEST_PATH]: ['webpack'] },
+    webpack: {
+      devtool: false,
+      entry: './test.js',
+    },
+    browsers: ['ChromeHeadless'],
+    // Explicitly turn off reporters so the simulated test results are not confused with the actual results.
+    reporters: [],
+    plugins: [karmaWebpack, karmaChromeLauncher, karmaMocha, karmaChai],
+    port: 2389,
+    logLevel: 'ERROR',
+    singleRun: true
+  };
+
+  beforeAll((done) => {
+    Scenario.run(config)
+      .then((res) => {
+        scenario = res;
+      })
+      .catch((err) => console.error('Integration Scenario Failed: ', err))
+      .finally(() => done());
+  }, KARMA_SERVER_TIMEOUT);
+
+  // karma-webpack should ignore the entry option and throw a warning.
+
+  it('should have an exit code of 1 because it contains a failing test', () => {
+    expect(scenario.exitCode).toBe(1);
+  })
+
+  it('should have three successful test runs', () => {
+    expect(scenario.success).toBe(3);
+  });
+
+  it('should have one failed test run', () => {
+    expect(scenario.failed).toBe(1);
+  });
+
+  it('should complete with no errors', () => {
+    expect(scenario.error).toBe(false);
+  });
+
+});


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

karma-webpack will no longer crash when an entry
option is set in webpack config, instead a warning
will be thrown and the property will be ignored
for the time being.

Fixes N/A

### Breaking Changes

N/A

### Additional Info

N/A