### PR TITLE
fix(test): don't use hardcoded tmp directory

### DIFF
--- a/test/unit/karma-webpack/controller.test.js
+++ b/test/unit/karma-webpack/controller.test.js
@@ -1,10 +1,12 @@
+const os = require('os');
+
 const KW_Controller = require('../../../lib/karma-webpack/controller');
 const DefaultWebpackOptionsFactory = require('../../../lib/webpack/defaults');
 
 const defaultWebpackOptions = DefaultWebpackOptionsFactory.create();
 
 describe('KW_Controller', () => {
-  const EXPECTED_DEFAULT_PATH_PREFIX = '/tmp/_karma_webpack_';
+  const EXPECTED_DEFAULT_PATH_PREFIX = '/_karma_webpack_';
 
   let controller;
 
@@ -18,7 +20,7 @@ describe('KW_Controller', () => {
   it('correctly sets the default output path prefix', () => {
     expect(
       controller.webpackOptions.output.path.startsWith(
-        EXPECTED_DEFAULT_PATH_PREFIX
+        os.tmpdir() + EXPECTED_DEFAULT_PATH_PREFIX
       )
     ).toBeTruthy();
   });


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

as it turns out os.tmpdir() is a function for a
reason :p. this changes the test to NOT use the
hardcoded tmp dir, but instead just use os.tmpdir
so that tests under other OSs will still pass.

Fixes N/A

### Breaking Changes

N/A

### Additional Info

N/A