### PR TITLE
feat(karma-webpack): added livereload capabilities

### DIFF
--- a/lib/karma-webpack/controller.js
+++ b/lib/karma-webpack/controller.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const WebpackDevServer = require('webpack-dev-server');
 const merge = require('webpack-merge');
 
 const KW_WebpackPlugin = require('../webpack/plugin');
@@ -74,7 +75,33 @@ defaulting ${newOptions.output.filename} to [name].js.`.trim()
     this.isActive = true;
 
     return new Promise((resolve) => {
-      if (this.webpackOptions.watch === true) {
+      if (this.webpackOptions.devServer) {
+        this.webpackOptions.watch = false;
+        this.webpackOptions.devServer.writeToDisk = true;
+
+        const { port, host } = this.webpackOptions.devServer;
+
+        this.compiler = webpack(this.webpackOptions);
+        const server = new WebpackDevServer(
+          this.compiler,
+          this.webpackOptions.devServer
+        );
+
+        this.compiler.hooks.done.tap('KW_Controller', (stats) => {
+          this.handleBuildResult('', stats, resolve);
+        });
+        this.compiler.hooks.failed.tap('KW_Controller', (err) => {
+          this.handleBuildResult(err);
+        });
+
+        server.listen(port, host, (err) => {
+          if (err) {
+            console.error(err);
+          }
+        });
+
+        this.setupExitHandler(server);
+      } else if (this.webpackOptions.watch === true) {
         console.log('Webpack starts watching...');
         this.compiler = webpack(this.webpackOptions, (err, stats) =>
           this.handleBuildResult(err, stats, resolve)

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "glob": "^7.1.3",
     "minimatch": "^3.0.4",
+    "webpack-dev-server": "^3.11.2",
     "webpack-merge": "^4.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
feat(karma-webpack): added livereload capabilities

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
Read use case here: #499

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
The only breaking change is:
if the user already used `devServer` webpack config property karma-webpack will be started in livereload mode.
This could be improved by adding some other config property that will tell karma-webpack to use the old behavior

### Additional Info
**Disclaimer**: This PR is not final because i'm not an expert neither in `karma-webpack` nor in `webpack/webpack-dev-server`
#### Some decisions should be made for this PR:
- how should we enable livereload? now livereload is triggered by the presence of `devServer` property in a webpack config. This might be considered a breaking change
- how should we configure livereload? for example in the current implementation `devServer.port` property is required. But we might want to create a completely isolated webpack-dev-server instance.



#### Support for new webpack config property
This PR adds support for webpack `devServer` config property.

If `devServer` property is added in the webpack config the following flow is used:
- instance of the webpack-dev-server is created. This instance will watch for source/test code changes and reload the browser page.
- if `devServer` property is used, then it is required to contain the `port` property.