### PR TITLE
test: add initial preprocessor test

### DIFF
--- a/test/unit/karma-webpack/controller.test.js
+++ b/test/unit/karma-webpack/controller.test.js
@@ -1,4 +1,5 @@
 const os = require('os');
+const { sep } = require('path');
 
 const KW_Controller = require('../../../lib/karma-webpack/controller');
 const DefaultWebpackOptionsFactory = require('../../../lib/webpack/defaults');
@@ -6,7 +7,7 @@ const DefaultWebpackOptionsFactory = require('../../../lib/webpack/defaults');
 const defaultWebpackOptions = DefaultWebpackOptionsFactory.create();
 
 describe('KW_Controller', () => {
-  const EXPECTED_DEFAULT_PATH_PREFIX = '/_karma_webpack_';
+  const EXPECTED_DEFAULT_PATH_PREFIX = `${sep}_karma_webpack_`;
 
   let controller;
 

--- a/test/unit/karma-webpack/preprocessor.test.js
+++ b/test/unit/karma-webpack/preprocessor.test.js
@@ -1,8 +1,63 @@
 const KW_Preprocessor = require('../../../lib/karma-webpack/preprocessor');
 
 describe('KW_Preprocessor', () => {
+  beforeAll(() => {
+    jest.mock('../../../lib/karma-webpack/controller');
+  });
+
+  afterAll(() => {
+    jest.unmock('../../../lib/karma-webpack/controller');
+  });
+
   it('should be defined', () => {
     expect(KW_Preprocessor).toBeDefined();
   });
-  // todo(mikol): write a KW_Preprocessor test suite before v5 official release.
+
+  it('should process a file', (done) => {
+    const config = {
+      files: [],
+      frameworks: ['webpack'],
+      preprocessors: {},
+      webpack: {},
+    };
+
+    expect(config.__karmaWebpackController).not.toBeDefined();
+
+    const processFile = KW_Preprocessor(config, {});
+
+    expect(config.__karmaWebpackController).toBeDefined();
+
+    // mock used fields
+    config.__karmaWebpackController.bundle = jest.fn(() => Promise.resolve());
+    config.__karmaWebpackController.bundlesContent = new Proxy(
+      {},
+      {
+        // usign a proxy because the key is the name with a hash
+        get() {
+          return 'bundle content';
+        },
+      }
+    );
+
+    const doneFn = jest.fn();
+
+    const file = {
+      path: 'some\\initial/path/initialfilename.js',
+      //         ^^
+      //          Added to make sure the "normalize" function is working
+      // However, unsure how we could check, only the file name is kept
+      // the rest of the path is ignored.
+    };
+
+    processFile('unused', file, doneFn);
+
+    Promise.resolve().then(() => {
+      const FILENAME_WITH_HASH_RE = /initialfilename\.(\d+)\.js/;
+      expect(FILENAME_WITH_HASH_RE.test(file.path)).toBe(true);
+      expect(config.__karmaWebpackController.bundle).toHaveBeenCalled();
+      expect(doneFn).toHaveBeenCalledWith(null, 'bundle content');
+
+      done();
+    });
+  });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
While working on NativeScript unit test runner, we ran into a few issues with the default config/setup of karma-webpack (5), however we were able to adjust the `default` config by simply patching it, so decided not to make changes & bloat karma-webpack with an extra flag/escape hatch.

One small "issue" remains with how the `file.path` is handled. The original (full) path is discarded, so `karma-server`'s `context.json` contains:
```bash
/absolute<testname>.<hash>.js?<anotherHash>
# instead of 
/base/<original-path>/<testname>.<hash>.js?<anotherHash>

# For example:
/app/tests/example.spec.js
# would become
/absoluteexample.spec.123123.js?hashhashhash
```
but unsure if changing that would affect anything else, we adjusted how we handle paths starting with `/absolute` - so no change required in `karma-webpack` from our end.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->
N/A

### Additional Info

The change in `controller.test.js` fixes the test on non-unix systems.

The test doesn't currently cover the `// one time setup` block.