### PR TITLE
fix(webpack): use path.resolve to create file path

### DIFF
--- a/lib/webpack/plugin.js
+++ b/lib/webpack/plugin.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 
 class KW_WebpackPlugin {
   constructor(options) {
@@ -14,9 +15,10 @@ class KW_WebpackPlugin {
       // read generated file content and store for karma preprocessor
       this.controller.bundlesContent = {};
       stats.toJson().assets.forEach((webpackFileObj) => {
-        const filePath = `${compiler.options.output.path}/${
+        const filePath = path.resolve(
+          compiler.options.output.path,
           webpackFileObj.name
-        }`;
+        );
         this.controller.bundlesContent[webpackFileObj.name] = fs.readFileSync(
           filePath,
           'utf-8'


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
I'm getting `no such file or directory` error from `karma-webpack`:
```
ERROR [karma-server]: Error: ENOENT: no such file or directory, open 13 07 2021 21:35:45.728:ERROR [karma-server]: Error: ENOENT: no such file or directory, open '/var/folders/fd/17654frj3379vn3wr07k_s_000jyn1/T/_karma_webpack_209189/../../../../../../Users/feiyangc/Projects/firebase-js-sdk/packages/logger/dist/src/logger.d.ts'
    at Object.openSync (fs.js:476:3)
    at Object.readFileSync (fs.js:377:35)
    at /Users/feiyangc/Projects/firebase-js-sdk/node_modules/karma-webpack/lib/webpack/plugin.js:24:66
    at Array.forEach (<anonymous>)
    at /Users/feiyangc/Projects/firebase-js-sdk/node_modules/karma-webpack/lib/webpack/plugin.js:17:29
    at Hook.eval [as callAsync] (eval at create (/Users/feiyangc/Projects/firebase-js-sdk/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:18:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Users/feiyangc/Projects/firebase-js-sdk/node_modules/tapable/lib/Hook.js:18:14)
    at /Users/feiyangc/Projects/firebase-js-sdk/node_modules/webpack/lib/Compiler.js:482:23
    at Compiler.emitRecords (/Users/feiyangc/Projects/firebase-js-sdk/node_modules/webpack/lib/Compiler.js:874:39)
    at /Users/feiyangc/Projects/firebase-js-sdk/node_modules/webpack/lib/Compiler.js:474:11 {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/var/folders/fd/17654frj3379vn3wr07k_s_000jyn1/T/_karma_webpack_209189/../../../../../../Users/feiyangc/Projects/firebase-js-sdk/packages/logger/dist/src/logger.d.ts'
}
```

I think the issue is that `/var` is a symlink to `/private/var`, and `readFileSync` incorrectly (or correctly?) resolve the path to `/private/Users/feiyangc/Projects/firebase-js-sdk/packages/logger/dist/src/logger.d.ts` while the correct path should be without `/private`.

Using `path.resolve` creates the correct file path.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info