### PR TITLE
fix: deleting hashing paths

### DIFF
--- a/lib/karma-webpack/preprocessor.js
+++ b/lib/karma-webpack/preprocessor.js
@@ -90,8 +90,6 @@ ignoring attempt to set the entry option...
       const transformedFilePath = transformPath(getPathKey(file.path, true));
       const bundleContent = controller.bundlesContent[transformedFilePath];
 
-      file.path = transformedFilePath;
-
       done(null, bundleContent);
     });
   };


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
After updating karma-webpack to the 5 version, the bundles specified in the files option were not loaded and i received 404 error.
This got fixed by removing path hashing in preprocessor.js `file.path = transformedFilePath;` and setting `optimization: {
     splitChunks: false,
     runtimeChunk: false,
}` in my karma.conf.js file

### Breaking Changes
N/A

### Additional Info
N/A