### PR TITLE
fix(karma-webpack) respect exclude list from config (#520)

### DIFF
--- a/lib/karma-webpack/preprocessor.js
+++ b/lib/karma-webpack/preprocessor.js
@@ -19,6 +19,10 @@ function configToWebpackEntries(config) {
   const { preprocessors } = config;
 
   let files = [];
+  const exclude = config.exclude || [];
+  const excluded = (filePath) =>
+    exclude.find((exPat) => minimatch(filePath, exPat));
+
   config.files.forEach((fileEntry, i) => {
     // forcefully disable karma watch as we use webpack watch only
     config.files[i].watched = false;
@@ -34,7 +38,7 @@ function configToWebpackEntries(config) {
   const filteredFiles = [];
   files.forEach((filePath) => {
     filteredPreprocessorsPatterns.forEach((pattern) => {
-      if (minimatch(filePath, pattern)) {
+      if (minimatch(filePath, pattern) && !excluded(filePath)) {
         filteredFiles.push(filePath);
       }
     });

--- a/test/integration/scenarios/basic-setup/basic-exclude.test.js
+++ b/test/integration/scenarios/basic-setup/basic-exclude.test.js
@@ -1,0 +1,67 @@
+/* eslint-disable prettier/prettier */
+
+import karmaChromeLauncher from 'karma-chrome-launcher';
+import karmaMocha from 'karma-mocha';
+import karmaChai from 'karma-chai';
+
+import Scenario from '../../utils/scenario';
+
+process.env.CHROME_BIN = require('puppeteer').executablePath();
+
+const path = require('path');
+
+const karmaWebpack = require('../../../../lib/index');
+
+// The karma server integration tests take longer than the jest 5 sec default,
+// we will give them 30 seconds to complete.
+const KARMA_SERVER_TIMEOUT = 30 * 1000;
+
+describe('A basic karma-webpack setup', () => {
+
+  let scenario;
+
+  const TEST_PATH_FAILING = path.resolve(__dirname, './index.scenario.js');
+  const TEST_PATH_PASSING = path.resolve(__dirname, './js-test-passes.js');
+
+  const config = {
+    frameworks: ['mocha', 'chai', 'webpack'],
+    files: [{ pattern: TEST_PATH_FAILING }, TEST_PATH_PASSING],
+    exclude: [TEST_PATH_FAILING],
+    preprocessors: { [TEST_PATH_FAILING]: ['webpack'] },
+    webpack: {},
+    browsers: ['ChromeHeadless'],
+    // Explicitly turn off reporters so the simulated test results are not confused with the actual results.
+    reporters: [],
+    plugins: [karmaWebpack, karmaChromeLauncher, karmaMocha, karmaChai],
+    port: 2389,
+    logLevel: 'ERROR',
+    singleRun: true
+  };
+
+  beforeAll((done) => {
+    jest.spyOn(console, 'log').mockImplementation()
+    Scenario.run(config)
+      .then((res) => {
+        scenario = res;
+      })
+      .catch((err) => console.error('Integration Scenario Failed: ', err))
+      .finally(() => done());
+  }, KARMA_SERVER_TIMEOUT);
+
+  it('should have an exit code of 0 because the failing file was excluded', () => {
+    expect(scenario.exitCode).toBe(0);
+  })
+
+  it('should have one successful test runs', () => {
+    expect(scenario.success).toBe(1);
+  });
+
+  it('should have zero failed test runs', () => {
+    expect(scenario.failed).toBe(0);
+  });
+
+  it('should complete with no errors', () => {
+    expect(scenario.error).toBe(false);
+  });
+
+});

--- a/test/integration/scenarios/basic-setup/custom-output-path.test.js
+++ b/test/integration/scenarios/basic-setup/custom-output-path.test.js
@@ -7,6 +7,7 @@ import karmaChai from 'karma-chai';
 import Scenario from '../../utils/scenario';
 
 const fs = require('fs');
+const os = require('os');
 
 process.env.CHROME_BIN = require('puppeteer').executablePath();
 
@@ -17,7 +18,7 @@ const karmaWebpack = require('../../../../lib/index');
 // The karma server integration tests take longer than the jest 5 sec default,
 // we will give them 30 seconds to complete.
 const KARMA_SERVER_TIMEOUT = 30 * 1000;
-const KARMA_CUSTOM_PATH = '/tmp/karma_webpack__custom_file_path';
+const KARMA_CUSTOM_PATH = path.join(os.tmpdir(), 'karma_webpack__custom_file_path');
 
 describe('A basic karma-webpack setup', () => {
   let scenario;

--- a/test/integration/scenarios/basic-setup/js-test-passes.js
+++ b/test/integration/scenarios/basic-setup/js-test-passes.js
@@ -1,0 +1,5 @@
+describe('quick maths', () => {
+  it('2 plus 2 is 4', () => {
+    assert.equal(2 + 2, 4);
+  });
+});

--- a/test/unit/karma-webpack/controller.test.js
+++ b/test/unit/karma-webpack/controller.test.js
@@ -1,4 +1,5 @@
 const os = require('os');
+const path = require('path');
 
 const KW_Controller = require('../../../lib/karma-webpack/controller');
 const DefaultWebpackOptionsFactory = require('../../../lib/webpack/defaults');
@@ -6,7 +7,7 @@ const DefaultWebpackOptionsFactory = require('../../../lib/webpack/defaults');
 const defaultWebpackOptions = DefaultWebpackOptionsFactory.create();
 
 describe('KW_Controller', () => {
-  const EXPECTED_DEFAULT_PATH_PREFIX = '/_karma_webpack_';
+  const EXPECTED_DEFAULT_PATH_PREFIX = '_karma_webpack_';
 
   let controller;
 
@@ -20,7 +21,7 @@ describe('KW_Controller', () => {
   it('correctly sets the default output path prefix', () => {
     expect(
       controller.webpackOptions.output.path.startsWith(
-        os.tmpdir() + EXPECTED_DEFAULT_PATH_PREFIX
+        path.join(os.tmpdir(), EXPECTED_DEFAULT_PATH_PREFIX)
       )
     ).toBeTruthy();
   });


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update**
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

resolves (#520)

### Breaking Changes

if you were excluding things you wanted to be run it will really be excluded now

### Additional Info

fixed some tests that did not pass when running on windows

i also couldn't find an easy way to confirm that it had not passed the config file as an entry point in the tests. for solving #520 this is reliant on karma having added the config file to the exclude list