### PR TITLE
Fix: serve generated assets

### DIFF
--- a/lib/karma-webpack/framework.js
+++ b/lib/karma-webpack/framework.js
@@ -16,6 +16,13 @@ function KW_Framework(config) {
   fs.closeSync(fs.openSync(commonsPath, 'w'));
   fs.closeSync(fs.openSync(runtimePath, 'w'));
 
+  // serve any generated Webpack assets/chunks:
+  config.files.unshift({
+    pattern: controller.outputPath + '/**',
+    included: false,
+    watched: true,
+  });
+
   // register for karma
   config.files.unshift({
     pattern: commonsPath,


### PR DESCRIPTION
When karma-webpack was switched to generating files on disk, only `commons.js` and `runtime.js` were configured to be served. This serves the rest of the contents of the output directory.


This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I am attempting to update from `karma-webpack@4`, but bundles/assets generated by loaders (like workerize-loader, the library I am updating) are being served as 404's. This happens because of the hard-coded list of output files.
